### PR TITLE
store previous_url in state

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Example usage -- 'custom-tag.tag'
   <div class={hidden: state.router.current_url !== 'page2'}>Page 2 is Great</div>
 
   <div>Current Page: {state.router.current_url}</div>
+  <div>Previous Page: {state.router.previous_url}</div>
 
   <style scoped>
     .hidden { display: none; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riot-redux-router",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "RiotJS Router + Redux Middleware",
   "main": "src/index.js",
   "scripts": {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -5,7 +5,10 @@ module.exports = function(state, action) {
 
   switch(action.type) {
     case actions.ROUTER_ROUTE_CHANGED:
-      return Object.assign({}, state, {current_url: action.data})
+      return Object.assign({}, state, {
+        current_url: action.data,
+        previous_url: state.current_url
+      })
     default:
       return state
   }

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -39,4 +39,23 @@ describe('#store', function() {
       secondUrl.substr(1)  // remove leading slash
     )
   })
+
+  it('should store previous_url', function() {
+    var firstUrl = '/foo'
+    var secondUrl = '/bar'
+
+    riot.route(firstUrl)
+    riot.route(secondUrl)
+
+    var state = store.getState()
+    assert.equal(
+      state.router.previous_url,
+      firstUrl.substr(1)  // remove leading slash
+    )
+    assert.equal(
+      state.router.current_url,
+      secondUrl.substr(1)  // remove leading slash
+    )
+  })
+
 })


### PR DESCRIPTION
Store previous_url in the state alongside current_url.

From https://github.com/collingreen/riot-redux-router/pull/1

Bumps version to 1.1.0