### PR TITLE
upgrade to riot-route v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 riot-redux-router
 -----------------
 
-Dead simple integration between the riot js router and redux.
+Dead simple integration between the riot js router (v3) and redux.
 
 Combine Riot's router and redux so you can easily dispatch route actions to
 simultaneously update your store and the browser url. Does very little else -
@@ -34,7 +34,6 @@ current url in the store.
 
 Example initialization - add the router.middleware to redux
 ```
-var riot = require('riot')
 var redux = require('redux')
 var router = require('riot-redux-router')
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riot-redux-router",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "RiotJS Router + Redux Middleware",
   "main": "src/index.js",
   "scripts": {
@@ -27,6 +27,6 @@
   },
   "dependencies": {
     "redux": "^3.7.2",
-    "riot": "^2.6.8"
+    "riot-route": "^3.1.2"
   }
 }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,4 +1,4 @@
-var riot = require('riot')
+var route = require('riot-route')
 
 var actions = require('./actions')
 
@@ -10,26 +10,26 @@ function riotRouterMiddleware(_ref) {
   var getState = _ref.getState
 
   // listen for riot router changes - re-dispatch with routeChanged
-  riot.route(function() {
+  route(function() {
     var args = Array.prototype.slice.call(arguments)
     dispatch(actions.routeChanged(args.join(separator)))
   })
 
   // set the base route separator
-  riot.route.base(separator)
+  route.base(separator)
 
-  // start listening to routes immediately
-  riot.route.start(true)
+  // start listening to routes immediately (required to pick up initial url)
+  route.start(true)
 
   return function (next) {
     return function (action) {
       // allow everything except ROUTER_GO_ACTION through
       if (action.type !== actions.ROUTER_GO_ACTION) {
         next(action)
+      } else {
+        // call riot router using action payload
+        route(action.data)
       }
-
-      // call riot router using action payload
-      riot.route(action.data)
     }
   }
 }

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -1,7 +1,7 @@
 var assert = require('chai').assert
 
 var redux = require('redux')
-var riot = require('riot')
+var route = require('riot-route')
 var rrr = require('../src/')
 
 var reducers = redux.combineReducers({
@@ -18,7 +18,7 @@ describe('#store', function() {
 
   it('should store the current route in the state', function() {
     var targetUrl = '/foo/bar/baz'
-    riot.route(targetUrl)
+    route(targetUrl)
     var state = store.getState()
     assert.equal(
       state.router.current_url,
@@ -30,8 +30,8 @@ describe('#store', function() {
     var firstUrl = '/foo'
     var secondUrl = '/bar'
 
-    riot.route(firstUrl)
-    riot.route(secondUrl)
+    route(firstUrl)
+    route(secondUrl)
 
     var state = store.getState()
     assert.equal(
@@ -44,8 +44,8 @@ describe('#store', function() {
     var firstUrl = '/foo'
     var secondUrl = '/bar'
 
-    riot.route(firstUrl)
-    riot.route(secondUrl)
+    route(firstUrl)
+    route(secondUrl)
 
     var state = store.getState()
     assert.equal(


### PR DESCRIPTION
Upgrade to riot v3 which separates the router from the riot core library.

From https://github.com/collingreen/riot-redux-router/pull/1
